### PR TITLE
Use keyword args when creating InfluxDB connection instead of keyword args.

### DIFF
--- a/flask_influxdb2.py
+++ b/flask_influxdb2.py
@@ -22,13 +22,13 @@ class InfluxDB2(object):
 
     def connect(self):
         return InfluxDBClient(
-            current_app.config['INFLUXDB_V2_URL'],
-            current_app.config['INFLUXDB_V2_TOKEN'],
-            current_app.config['INFLUXDB_V2_DEBUG'],
-            current_app.config['INFLUXDB_V2_TIMEOUT'],
-            current_app.config['INFLUXDB_V2_ORG'],
-            current_app.config['INFLUXDB_V2_ENABLE_GZIP'],
-            current_app.config['INFLUXDB_V2_DEFAULT_DICT'],
+            url=current_app.config['INFLUXDB_V2_URL'],
+            token=current_app.config['INFLUXDB_V2_TOKEN'],
+            debug=current_app.config['INFLUXDB_V2_DEBUG'],
+            timeout=current_app.config['INFLUXDB_V2_TIMEOUT'],
+            enable_gzip=current_app.config['INFLUXDB_V2_ENABLE_GZIP'],
+            org=current_app.config['INFLUXDB_V2_ORG'],
+            default_tags=current_app.config['INFLUXDB_V2_DEFAULT_DICT'],
         )
 
     def teardown(self, exception):


### PR DESCRIPTION
It seems like that either the order of positional arguments in infuxdb_client changed or some way this library have mixed up the order. But the enable_gzip and the organization parameter were swapped in the connect() function.

To avoid this in the future, I suggest changing the positional arguments to keyword arguments. This way the change of the order in the influxdb_client library won't affect the functionality of this library.